### PR TITLE
Issues/1 events 411

### DIFF
--- a/assets/js/wc-nyp-tickets-admin.js
+++ b/assets/js/wc-nyp-tickets-admin.js
@@ -12,11 +12,11 @@
 	    }
 	});
 
-	$( '#tribetickets' )
+	
 
 
 	/* Trigger chance on edit ticket */
-	$document.on( 'edit-ticket.tribe', function( event ) {}
+	$( '#event_tickets' ).on( 'event-tickets-plus-ticket-meta-initialized.tribe', function( event ) {
 		$( '#event_tickets' ).find( '#ticket_is_nyp' ).change();
 	} );
 

--- a/assets/js/wc-nyp-tickets-admin.js
+++ b/assets/js/wc-nyp-tickets-admin.js
@@ -1,9 +1,9 @@
 ( function( $ ) {
 	
 	// Hide show the NYP/price fields depending on NYP checkbox.
-	$( document.getElementById( 'event_tickets' ) ).on( 'change', '#ticket_is_nyp', function( event ) {
+	$( '#tribetickets' ).on( 'change', '#ticket_is_nyp', function( event ) {
 
-	    var $ticket_price_div = $( document.getElementById( 'event_tickets' ) ).find( '#ticket_price' ).closest( '.input_block' );
+	    var $ticket_price_div = $( '#event_tickets' ).find( '#ticket_price' ).closest( '.input_block' );
 	    
 	    if( $(this).is( ':checked' ) ){
 	        $ticket_price_div.hide();
@@ -12,7 +12,12 @@
 	    }
 	});
 
-	// Hide price fields on "new" ticket. (not working yet)
-	$( document.getElementById( 'event_tickets' ) ).find( '#ticket_is_nyp' ).change();
+	$( '#tribetickets' )
+
+
+	/* Trigger chance on edit ticket */
+	$document.on( 'edit-ticket.tribe', function( event ) {}
+		$( '#event_tickets' ).find( '#ticket_is_nyp' ).change();
+	} );
 
 } ) ( jQuery );

--- a/assets/js/wc-nyp-tickets-admin.min.js
+++ b/assets/js/wc-nyp-tickets-admin.min.js
@@ -1,3 +1,3 @@
-/*!  1.1.1 2019-11-30 11:24 */
+/*!  2.0.0-beta.1 2020-11-12 11:08 */
 
-!function(n){n(document.getElementById("event_tickets")).on("change","#ticket_is_nyp",function(e){var t=n(document.getElementById("event_tickets")).find("#ticket_price").closest(".input_block");n(this).is(":checked")?t.hide():t.show()}),n(document.getElementById("event_tickets")).find("#ticket_is_nyp").change()}(jQuery);
+!function(i){i("#tribetickets").on("change","#ticket_is_nyp",function(t){var e=i("#event_tickets").find("#ticket_price").closest(".input_block");i(this).is(":checked")?e.hide():e.show()}),i("#event_tickets").on("event-tickets-plus-ticket-meta-initialized.tribe",function(t){i("#event_tickets").find("#ticket_is_nyp").change()})}(jQuery);

--- a/includes/class-tribe-tickets-nyp-template.php
+++ b/includes/class-tribe-tickets-nyp-template.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Allow including of Gutenberg Template
+ *
+ * @since 2.0.0
+ */
+class Tribe__Tickets__NYP__Template extends Tribe__Tickets_Plus__Template {
+
+	/**
+	 * Building of the Class template configuration
+	 *
+	 * @since 2.0.0
+	 */
+	public function __construct() {
+
+		$this->set_template_origin( WC_NYP_Tickets::instance() );
+		$this->set_template_folder( 'templates' );
+
+		// Configures this templating class to extract variables.
+		$this->set_template_context_extract( true );
+
+		// Uses the public folders.
+		$this->set_template_folder_lookup( true );
+	}
+
+}
+

--- a/includes/class-wc-nyp-tickets-admin.php
+++ b/includes/class-wc-nyp-tickets-admin.php
@@ -20,6 +20,12 @@ class WC_NYP_Tickets_Admin {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'meta_box_script' ) );
 		add_action( 'tribe_events_tickets_metabox_edit_main', array( __CLASS__, 'do_metabox_advanced_options' ), 5, 2 );
 		add_action( 'event_tickets_after_save_ticket', array( __CLASS__, 'save_nyp_data' ), 10, 4 );
+
+
+		add_action( 'event_tickets_ticket_list_before_ticket_name', array( __CLASS__, 'add_price_filters' ), 10, 2 );
+
+		add_filter( 'tribe_events_wootickets_ticket_price_html', array( __CLASS__, 'ticket_price_html' ), 10, 2 );
+
 	}
 
     /*-----------------------------------------------------------------------------------*/
@@ -32,16 +38,15 @@ class WC_NYP_Tickets_Admin {
 	 *
 	 * @param int $event_id
 	 * @param int $ticket_id
-	 * @return void
 	 * @since 1.0.0
 	 */
 	public static function do_metabox_advanced_options( $event_id, $ticket_id ) {
 
 		$ticket_product = wc_get_product( $ticket_id );
 		
-		$is_nyp          = $ticket_product instanceOf WC_Product ? $ticket_product->get_meta( '_nyp', true, 'edit' ) : 'no';
-		$suggested_price = $ticket_product instanceOf WC_Product ? $ticket_product->get_meta( '_suggested_price', true, 'edit' ) : '';
-		$minimum_price   = $ticket_product instanceOf WC_Product ? $ticket_product->get_meta( '_min_price', true, 'edit' ) : '';
+		$is_nyp          = wc_bool_to_string( WC_Name_Your_Price_Helpers::is_nyp( $ticket_product ) );
+		$suggested_price = WC_Name_Your_Price_Helpers::get_suggested_price( $ticket_product );
+		$minimum_price   = WC_Name_Your_Price_Helpers::get_minimum_price( $ticket_product );
 
 		?>
 		
@@ -83,26 +88,41 @@ class WC_NYP_Tickets_Admin {
 	 * @param array                         Ticket data
 	 * @param string                        Commerce engine class
 	 */
-	public static function save_nyp_data( $post_id, $ticket, $raw_data, $commerce ){
+	public static function save_nyp_data( $post_id, $ticket, $raw_data, $commerce ) {
 
 		$product = wc_get_product( $ticket->ID );
 
 		if ( $product instanceOf WC_Product ) {
 
+			// Is this ticket NYP or not.
 		   	if ( isset( $raw_data['ticket_is_nyp'] ) ) {
+
 				$product->update_meta_data( '_nyp', 'yes' );
-				// removing the sale price removes NYP items from Sale shortcodes
+
+				// Removing the sale price removes NYP items from Sale shortcodes
 				$product->set_sale_price( '' );
 				$product->delete_meta_data( '_has_nyp' );
+
+		   		// Update that the Event has NYP tickets.
+		   		update_post_meta( $post_id, '_has_nyp', 'yes' );
+
 			} else {
+
 				$product->update_meta_data( '_nyp', 'no' );
+
+				// Check the other tickets, any still NYP?
+				$has_nyp = WC_NYP_Tickets()->event_has_nyp( $post_id, true ) ? 'yes' : 'no';
+				update_post_meta( $post_id, '_has_nyp', $has_nyp );
+
 			}
 
+			// Save suggested price.
 			if ( isset( $raw_data['suggested_ticket_price'] ) ) {
 				$suggested = ( trim( $raw_data['suggested_ticket_price'] ) === '' ) ? '' : wc_format_decimal( $raw_data['suggested_ticket_price'] );
 				$product->update_meta_data( '_suggested_price', $suggested );
 			}
 
+			// Save minimum price.
 			if ( isset( $raw_data['min_ticket_price'] ) ) {
 				$minimum = ( trim( $raw_data['min_ticket_price'] ) === '' ) ? '' : wc_format_decimal( $raw_data['min_ticket_price'] );
 				$product->update_meta_data( '_min_price', $minimum );
@@ -156,6 +176,55 @@ class WC_NYP_Tickets_Admin {
 		}
 
 	}	
+
+
+	/**
+	 * Trick .
+	 *
+	 * @since  2.0.0
+	 *
+	 * @param Tribe__Tickets__Ticket_Object $ticket       The current ticket object.
+	 * @param Tribe__Tickets__Tickets       $provider_obj The current ticket provider object.
+	 */
+	public static function add_price_filters( $ticket, $provider_obj ) {
+		add_filter( 'woocommerce_product_get_price', array( __CLASS__, 'ticket_price' ), 10, 2 );
+	}
+
+	
+	/**
+	 * Ticket price, trick Events Tickets into always display the price html, which IS filterable.
+	 *
+	 * @since  2.0.0
+	 * 
+	 * @param string $price
+	 * @param mixed  $product
+	 *
+	 * @return string
+	 */
+	public static function ticket_price( $price, $product ) {
+		if ( WC_Name_Your_Price_Helpers::is_nyp( $product ) ) {
+			$price = 1;
+		}
+		return $price;
+	}
+
+
+	/**
+	 * Ticket price html
+	 *
+	 * @since  2.0.0
+	 *
+	 * @param string $price_html
+	 * @param mixed  $product
+	 *
+	 * @return string
+	 */
+	public static function ticket_price_html( $price_html, $product ) {
+		if ( WC_Name_Your_Price_Helpers::is_nyp( $product ) ) {
+			$price_html = wc_get_price_html_from_text() . WC_Name_Your_Price_Helpers::get_price_string( $product, 'minimum', true );
+		}
+		return $price_html;
+	}
 
 }
 WC_NYP_Tickets_Admin::init();

--- a/includes/class-wc-nyp-tickets-admin.php
+++ b/includes/class-wc-nyp-tickets-admin.php
@@ -18,7 +18,7 @@ class WC_NYP_Tickets_Admin {
 	 */
 	public static function init() {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'meta_box_script' ) );
-		add_action( 'tribe_events_tickets_metabox_edit_main', array( __CLASS__, 'do_metabox_advanced_options' ), 10, 2 );
+		add_action( 'tribe_events_tickets_metabox_edit_main', array( __CLASS__, 'do_metabox_advanced_options' ), 5, 2 );
 		add_action( 'event_tickets_after_save_ticket', array( __CLASS__, 'save_nyp_data' ), 10, 4 );
 	}
 

--- a/includes/class-wc-nyp-tickets-cart.php
+++ b/includes/class-wc-nyp-tickets-cart.php
@@ -20,7 +20,7 @@ class WC_NYP_Tickets_Cart {
 	 */
 	public function __construct() {
 
-		// NYP needs a suffix to handle multiple inputs on the same page
+		// NYP needs a suffix to handle multiple inputs on the same page.
 		add_filter( 'wc_nyp_field_suffix', array( $this, 'nyp_cart_suffix_for_tickets' ), 9, 2 );
 
 	}
@@ -35,7 +35,7 @@ class WC_NYP_Tickets_Cart {
 	 * @since  1.0.0
 	 */
 	public function nyp_cart_suffix_for_tickets( $suffix, $product_id ) {
-		if( isset( $_POST['wootickets_process'] ) && $_POST['wootickets_process'] == 1 ){
+		if( tribe_events_product_is_ticket( $product_id ) ) {
 			$suffix = '-ticket-' . $product_id;
 		}
 		return $suffix;

--- a/includes/class-wc-nyp-tickets-display.php
+++ b/includes/class-wc-nyp-tickets-display.php
@@ -23,11 +23,16 @@ class WC_NYP_Tickets_Display {
 	 */
 	public function __construct() {
 
+		include_once 'class-tribe-tickets-nyp-template.php';
+		tribe_singleton( 'tickets-plus.nyp.template', 'Tribe__Tickets__NYP__Template' );
+
+		add_filter( 'post_class', array( $this, 'post_class' ), 10, 3 );
 		add_filter( 'tribe_get_cost', array( $this, 'nyp_event_cost' ), 10, 3 );
-		add_filter( 'tribe_events_tickets_woo_cart_class', array( $this, 'add_form_class' ) );
-		add_filter( 'tribe_events_tickets_row_class', array( $this, 'add_row_class' ) );
-		add_filter( 'tribe_events_wootickets_ticket_price_html', array( $this, 'nyp_ticket_price' ), 10, 3 );
-		add_action( 'wp_enqueue_scripts', array( $this, 'load_nyp_scripts' ), 20 );
+		add_filter( 'wc_nyp_data_attributes', array( $this, 'optional_nyp_attributes' ), 10, 2 );
+		
+		add_filter( 'tribe_template_html:tickets/blocks/tickets/extra-price', array( $this, 'ticket_nyp_html' ), 10, 4 );
+
+		add_action( 'wp_head', array( $this, 'ticket_nyp_css' ) );
 
 	}
 
@@ -36,57 +41,188 @@ class WC_NYP_Tickets_Display {
 	/*-----------------------------------------------------------------------------------*/
 
 	/**
+	 * Add a post class to Events with NYP tickets.
+	 *
+	 * @since  2.0.0
+	 *
+	 * @param string[] $classes An array of post class names.
+	 * @param string[] $class Additional class names.
+	 * @param int	$post_id The event ID.
+	 * @return array
+	 */
+	public function post_class( $classes, $class, $post_id ) {
+
+		if ( WC_NYP_Tickets()->event_has_nyp( $post_id ) ) {
+			$classes[] = 'has-nyp-tickets';
+		}
+				
+		return $classes;
+	}
+
+	/**
 	 * Hide the Event cost if any tickets are NYP
+	 *
+	 * @since  1.0.0
 	 *
 	 * @param str $cost
 	 * @param id	$post_id // the event ID
 	 * @param bool	$with_currency_symbol
 	 * @return str
-	 * @since  1.0.0
 	 */
-	public function nyp_event_cost( $cost, $post_id, $with_currency_symbol ){
-		if( class_exists( 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main' ) ){
-			// get instance of Woo Tickets class
-			$wootickets = Tribe__Tickets_Plus__Commerce__WooCommerce__Main::get_instance();
-			
-			// get all tickets for event
-			$tickets = $wootickets->get_tickets_ids( $post_id );
-			
-			// if any NYP tickets, create new price strings
-			if( $tickets ){
-				
-				$all_nyp = true;
-				$has_nyp = false;
-				$min_price = null;
-			
-				foreach ( $tickets as $ticket ){
-					if ( WC_Name_Your_Price_Helpers::is_nyp( $ticket ) ){
-						$has_nyp = true;
-						$ticket_price = WC_Name_Your_Price_Helpers::get_minimum_price( $ticket );
-					} else {
-						$all_nyp = false;
-						$product = wc_get_product( $ticket );
-						$ticket_price = $product->get_price();
-					}
-				}
-			
-				if( $all_nyp ){
-					$cost = apply_filters( 'wc_nyp_events_all_nyp_tickets_cost_string', '', $post_id );
-				} elseif ( $has_nyp ) {
-					$cost = apply_filters( 'wc_nyp_events_has_nyp_tickets_cost_string', __( 'See tickets below for pricing', 'wc-nyp-tickets' ), $post_id );
-				}
-			}
+	public function nyp_event_cost( $cost, $post_id, $with_currency_symbol ) {
+
+		if ( WC_NYP_Tickets()->event_has_nyp( $post_id ) ) {
+			$cost = apply_filters( 'wc_nyp_events_has_nyp_tickets_cost_string', __( 'See below for pricing', 'wc-nyp-tickets' ), $post_id );
 		}
-		
+				
 		return $cost;
 	}
 
 	/**
+	 * Load NYP scripts for front-end validation
+	 *
+	 * @since  1.1.0
+	 */
+	public function load_nyp_scripts() {
+					
+			WC_Name_Your_Price()->display->nyp_scripts();
+
+			wp_add_inline_script( 'woocommerce-nyp', '
+				jQuery( function( $ ) {
+					$( ".tribe-tickets" ).each(	function() {
+
+						var $ticket_form = $(this);
+
+						if ( "woo" !== $ticket_form.data( "provider-id" ) ) {
+							return;
+						}
+
+						$ticket_form.addClass( "cart" );
+
+						// Update totals when price is changed.
+						$( ".nyp" ).on( "wc-nyp-updated", function( event, nypProduct ) {
+							var $ticket = $( this ).closest( ".nyp-product" );
+							$ticket.find( ".tribe-tickets__sale_price .tribe-amount" ).html( nypProduct.getPrice() );
+							$ticket.find( "input.tribe-tickets-quantity" ).trigger( "change" );
+						} );
+
+						// Handle status of optional tickets.
+						$ticket_form.find( "input.tribe-tickets-quantity" ).on( "change", function( event) {
+							var $nyp = $( this ).closest( ".nyp-product" ).find( ".nyp" );
+
+							if ( $nyp.length ) {
+								var selected = $( this ).val() > 0;
+								$nyp.data( "optional_status", selected );
+							}
+
+						} );
+
+						// Run validation on submit, by switching the add to cart button element.
+						$ticket_form.on( "wc-nyp-initializing", function( event, nypForm ) {
+							nypForm.$add_to_cart = $ticket_form.find( "#tribe-tickets__buy" );
+						} );
+
+						$( this ).wc_nyp_form();
+					} );
+
+				} );
+
+			' );
+	}
+
+
+	/**
+	 * Mark products as optional.
+	 *
+	 * @since 2.0.0
+	 * 
+	 * @param array      $attributes - The data attributes on the NYP div.
+	 * @param  WC_Product $product
+	 * @return array
+	 */
+	public function optional_nyp_attributes( $attributes, $product ) {
+
+		if ( tribe_events_product_is_ticket( $product->get_id() ) ) {
+			$attributes['optional'] = 'yes';
+		}
+		return $attributes;
+	}
+
+
+	/**
+	 * Mark products as optional.
+	 *
+	 * @since 2.0.0
+	 * @see https://docs.theeventscalendar.com/reference/hooks/tribe_template_htmlhook_name/
+	 * 
+	 * @param string $html      The final HTML
+	 * @param string $file      Complete path to include the PHP File
+	 * @param array  $name      Template name
+	 * @param self   $template  Current instance of the Tribe__Template
+	 * @return string
+	 */
+	public function ticket_nyp_html( $html, $file, $name, $template ) {
+		
+		/** @var Tribe__Tickets__Tickets $provider */
+		$provider = $template->get( 'provider' );
+
+		if ( 'woo' === $provider->orm_provider ) {
+
+			/** @var Tribe__Tickets__Ticket_Object $ticket */
+			$ticket = $template->get( 'ticket' );
+
+			/** @var Tribe__Tickets__NYP__Template $template */
+	  		$template = tribe( 'tickets-plus.nyp.template' );
+
+			if ( WC_Name_Your_Price_Helpers::is_nyp( $ticket->ID ) ) {
+
+				$this->load_nyp_scripts();
+
+				$html = $template->template( 'blocks/tickets/nyp-price', [ 'ticket' => $ticket, 'provider' => $provider ], false );
+			}
+
+		}
+
+		return $html;
+	}
+
+
+	/**
+	 * Mark products as optional.
+	 *
+	 * @since 2.0.0
+	 */
+	public function ticket_nyp_css() { ?>
+		
+		<style>
+			@media (min-width: 768px) {
+				.has-nyp-tickets .tribe-common .tribe-tickets__item, .has-nyp-tickets.entry .entry-content .tribe-common .tribe-tickets__item {
+					-ms-grid-columns: 6.6fr 4fr 2fr;
+					grid-template-columns: 6.5fr 3fr 2fr;
+					-ms-grid-rows: 1fr 1.5fr 1fr;
+				}
+			}
+			.has-nyp-tickets .tribe-common.tribe-tickets {
+				max-width: initial;
+			}
+			
+		</style>
+
+		<?php
+	}
+
+	/*-----------------------------------------------------------------------------------*/
+	/* Deprecated */
+	/*-----------------------------------------------------------------------------------*/
+
+	/**
 	 * Adds cart_group class to cart form, causes NYP to look for nested cart classes
 	 *
+	 * @since  1.0.0
+	 * @deprecated 2.0.0 Events Tickets no longer has this filter.
+	 * 
 	 * @param array $class
 	 * @return array
-	 * @since  1.0.0
 	 */
 	public function add_form_class( $classes ) {
 		$classes[] = 'cart_group';
@@ -96,9 +232,11 @@ class WC_NYP_Tickets_Display {
 	/**
 	 * Adds cart class to input wrapper <tr>
 	 *
+	 * @since  1.0.0
+	 * @deprecated 2.0.0 Events Tickets no longer has this filter.
+	 * 
 	 * @param array $classes
 	 * @return array
-	 * @since  1.1.0
 	 */
 	public function add_row_class( $classes ) {
 		$classes[] = 'cart';
@@ -108,18 +246,20 @@ class WC_NYP_Tickets_Display {
 	/**
 	 * Change the display price of paid tickets OR display price inputs
 	 *
+	 * @since  1.0.3
+	 * @deprecated 2.0.0 Use a custom template.
+	 *
 	 * @param obj $ticket
 	 * @param obj $product
 	 * @return void
-	 * @since  1.0.3
 	 */
-	public function nyp_ticket_price( $price_html, $product, $attendee ){
+	public function nyp_ticket_price( $price_html, $product, $attendee ) {
 		if( tribe_is_event() && WC_Name_Your_Price_Helpers::is_nyp( $product ) ) {
-			if( isset( $attendee['order_id'] ) && isset( $attendee['order_item_id'] ) ){
+			if( isset( $attendee['order_id'] ) && isset( $attendee['order_item_id'] ) ) {
 				$order = wc_get_order( $attendee['order_id'] );
 				$order_items = $order->get_items();
 				$order_item_id = $attendee['order_item_id'];
-				if( isset( $order_items[$order_item_id] ) ){
+				if( isset( $order_items[$order_item_id] ) ) {
 					$line_item = $order_items[$order_item_id];
 					$price_html = $order->get_formatted_line_subtotal( $line_item );
 				}
@@ -134,18 +274,6 @@ class WC_NYP_Tickets_Display {
 		return $price_html;
 	}
 
-	/**
-	 * Load NYP scripts for front-end validation
-	 *
-	 * @return void
-	 * @since  1.1.0
-	 */
-	public function load_nyp_scripts(){
-		if( function_exists( 'tribe_is_event' ) && tribe_is_event() ) {
-			WC_Name_Your_Price()->display->nyp_scripts();
-		}
-	}
-
-} //end class
+} // End class.
 
 return new WC_NYP_Tickets_Display();

--- a/languages/wc-nyp-tickets.pot
+++ b/languages/wc-nyp-tickets.pot
@@ -1,55 +1,56 @@
-# Copyright (C) 2019 Kathy Darling
+# Copyright (C) 2020 Kathy Darling
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Name Your Price Event Tickets 1.1.1\n"
+"Project-Id-Version: WooCommerce Name Your Price - Event Tickets "
+"2.0.0-beta.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wc-nyp-event-tickets\n"
-"POT-Creation-Date: 2019-11-30 18:34:14+00:00\n"
+"POT-Creation-Date: 2020-11-12 18:08:20+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2020-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"
 
-#: includes/class-wc-nyp-tickets-admin.php:50
+#: includes/class-wc-nyp-tickets-admin.php:55
 msgid "Name Your Price"
 msgstr ""
 
-#: includes/class-wc-nyp-tickets-admin.php:53
+#: includes/class-wc-nyp-tickets-admin.php:58
 msgid "Customers are allowed to determine their own price."
 msgstr ""
 
-#: includes/class-wc-nyp-tickets-admin.php:59
+#: includes/class-wc-nyp-tickets-admin.php:64
 msgid "Suggested Price:"
 msgstr ""
 
-#: includes/class-wc-nyp-tickets-admin.php:62
+#: includes/class-wc-nyp-tickets-admin.php:67
 msgid "Price to pre-fill for customers.  Leave blank to not suggest a price."
 msgstr ""
 
-#: includes/class-wc-nyp-tickets-admin.php:68
+#: includes/class-wc-nyp-tickets-admin.php:73
 msgid "Minimum Price:"
 msgstr ""
 
-#: includes/class-wc-nyp-tickets-admin.php:71
+#: includes/class-wc-nyp-tickets-admin.php:76
 msgid "Lowest acceptable price for ticket. Leave blank to not enforce a minimum."
 msgstr ""
 
-#: includes/class-wc-nyp-tickets-display.php:76
-msgid "See tickets below for pricing"
+#: includes/class-wc-nyp-tickets-display.php:75
+msgid "See below for pricing"
 msgstr ""
 
-#: wc-nyp-tickets.php:124
+#: wc-nyp-tickets.php:136
 msgid ""
 "<strong>Name Your Price Tickets is inactive.</strong> The %sWooCommerce "
 "plugin%s must be active and at least version %s for Name Your Price Tickets "
 "to function. Please upgrade or activate WooCommerce."
 msgstr ""
 
-#: wc-nyp-tickets.php:132
+#: wc-nyp-tickets.php:144
 msgid ""
 "<strong>Name Your Price Tickets is inactive.</strong> The %sWooCommerce "
 "Name Your Price plugin%s must be active and at least version %s for Name "
@@ -57,7 +58,7 @@ msgid ""
 "Your Price."
 msgstr ""
 
-#: wc-nyp-tickets.php:140
+#: wc-nyp-tickets.php:152
 msgid ""
 "<strong>Name Your Price Tickets is inactive.</strong> The %sEvents Tickets "
 "Plus plugin%s must be active and at least version %s for Name Your Price "
@@ -65,7 +66,7 @@ msgid ""
 msgstr ""
 
 #. Plugin Name of the plugin/theme
-msgid "WooCommerce Name Your Price Event Tickets"
+msgid "WooCommerce Name Your Price - Event Tickets"
 msgstr ""
 
 #. Plugin URI of the plugin/theme

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-nyp-tickets",
-  "version": "1.1.1",
+  "version": "2.0.0-beta.1",
   "license": "GPL-3.0",
   "main": "Gruntfile.js",
   "author": "Kathy Darling",

--- a/readme.md
+++ b/readme.md
@@ -6,16 +6,13 @@
 **Stable tag:** 2.0.0-beta.1
 **License:** GPLv3      
 **License URI:** http://www.gnu.org/licenses/gpl-3.0.html      
-**WC requires at least:** 2.6.4      
-**WC tested up to:** 2.6.4     
+**WC requires at least:** 4.0.0      
+**WC tested up to:** 4.7.0     
 
 Add Name Your Price Support to Events Tickets
 
-Requires Requires WooCommerce 3.0+, The Events Calendar 4.3.3, Event Tickets 4.3.3, and Events Tickets Plus 4.3.3
+Requires Requires WooCommerce 4.0+, The Events Calendar 5.0+, Event Tickets 5.0+, and Events Tickets Plus 5.0+
 
-*NOTE* This appears to no longer add compatibility as of Events 4.11.0.
+![Front end price input for ticket, a ticket name appears in the table with a text input for the price.](https://user-images.githubusercontent.com/507025/99322524-56cf5600-282d-11eb-8c48-896f73eb14d9.png "Front end price input for ticket")
 
-![Front end price input for ticket](https://user-images.githubusercontent.com/507025/69904585-231dc680-1365-11ea-8bae-98a6e9f2add3.png "Front end price input for ticket")
-
-![Backend checkbox to toggle Name Your Price functionality for ticket](https://user-images.githubusercontent.com/507025/69904536-cd491e80-1364-11ea-8a91-d2f32ea8de43.png "Backend checkbox to toggle Name Your Price functionality for ticket")
-
+![Backend checkbox to toggle Name Your Price functionality for ticket, a checkbox toggles Name Your Price on and off. When on suggested and minimum price fields appear.](https://user-images.githubusercontent.com/507025/99322461-38695a80-282d-11eb-845d-30dbaa69ebb8.png "Backend checkbox to toggle Name Your Price functionality for ticket")

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Contributors:** [Kathy Darling](https://profiles.wordpress.org/helgatheviking)  
 **Requires at least:** 4.6.1      
 **Tested up to:** 4.6.1      
-**Stable tag:** 1.1.1
+**Stable tag:** 2.0.0-beta.1
 **License:** GPLv3      
 **License URI:** http://www.gnu.org/licenses/gpl-3.0.html      
 **WC requires at least:** 2.6.4      

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: Kathy Darling    
 Requires at least: 4.6.1    
 Tested up to: 4.6.1    
-Stable tag: 1.1.1
+Stable tag: 2.0.0-beta.1
 License: GPLv3    
 License URI: http://www.gnu.org/licenses/gpl-3.0.html    
 WC requires at least: 2.6.4    

--- a/templates/blocks/tickets/nyp-price.php
+++ b/templates/blocks/tickets/nyp-price.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Block: Tickets
+ * Extra column, price
+ *
+ * Override this template in your own theme by creating a file at:
+ * [your-theme]/tribe/tickets/blocks/tickets/nyp-price.php
+ *
+ * See more documentation about our Blocks Editor templating system.
+ *
+ * @version 2.0.0
+ */
+
+$classes = [ 'tribe-common-b2', 'tribe-common-b1--min-medium', 'tribe-tickets__item__extra__price' ];
+/** @var Tribe__Tickets__Ticket_Object $ticket */
+$ticket     = $this->get( 'ticket' );
+$has_suffix = ! empty( $ticket->price_suffix );
+
+/** @var Tribe__Tickets__Tickets $provider */
+$provider = $this->get( 'provider' );
+$provider_class = $provider->class_name;
+
+?>
+<div <?php tribe_classes( $classes ); ?>>
+
+	<span class="tribe-common-b2">
+		<?php echo WC_Name_Your_Price()->display->display_price_input( $ticket->ID, '-ticket-' . $ticket->ID ); ?>
+	</span>
+	<span class="tribe-tickets__sale_price">
+		<span style="display:none;" class="tribe-amount"></span>
+	</span>
+
+</div>

--- a/wc-nyp-tickets.php
+++ b/wc-nyp-tickets.php
@@ -143,7 +143,7 @@ class WC_NYP_Tickets {
 			$has_min_environment = false;
 		}
 
-		if( ! empty( $notices ) ) { error_log(json_encode( $notices));
+		if( ! empty( $notices ) ) {
 			update_option( 'wc_nyp_tickets_notices', $notices );
 		}
 		return $has_min_environment;

--- a/wc-nyp-tickets.php
+++ b/wc-nyp-tickets.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Name Your Price - Event Tickets
  * Plugin URI:  http://github.com/helgatheviking/woocommerce-name-your-price-tickets
  * Description: Bridge plugin for adding NYP support to Modern Tribe&#39;s Tickets Plus
- * Version: 1.1.1
+ * Version: 2.0.0-beta.1
  * Author:      Kathy Darling
  * Author URI:  http://www.kathyisawesome.com
  * License: GNU General Public License v3.0
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WC_NYP_Tickets' ) ) :
 
 class WC_NYP_Tickets {
 
-	const VERSION = '1.1.1';
+	const VERSION = '2.0.0-beta.1';
 	const PREFIX  = 'WC_NYP_Tickets';
 	const REQUIRED_WC = '4.7.0';
 	const REQUIRED_NYP = '3.0.0';

--- a/wc-nyp-tickets.php
+++ b/wc-nyp-tickets.php
@@ -11,9 +11,9 @@
  * Text Domain: wc-nyp-tickets
  * Domain Path: /languages
  * Requires at least: 5.0.0
- * Tested up to: 5.3.0
- * WC requires at least: 3.6.0
- * WC tested up to: 3.8.0   
+ * Tested up to: 5.5.0
+ * WC requires at least: 4.7.0
+ * WC tested up to: 4.7.0   
  */
 
 /**
@@ -31,9 +31,9 @@ class WC_NYP_Tickets {
 
 	const VERSION = '1.1.1';
 	const PREFIX  = 'WC_NYP_Tickets';
-	const REQUIRED_WC = '3.6.0';
-	const REQUIRED_NYP = '2.10.0';
-	const REQUIRED_TICKETS = '4.10.0';
+	const REQUIRED_WC = '4.7.0';
+	const REQUIRED_NYP = '3.0.0';
+	const REQUIRED_TICKETS = '5.0.0';
 
 	/**
 	 * @var WC_NYP_Tickets - the single instance of the class

--- a/wc-nyp-tickets.php
+++ b/wc-nyp-tickets.php
@@ -104,7 +104,7 @@ class WC_NYP_Tickets {
 		}
 
 		// Load core files.
-		add_action( 'plugins_loaded', array( $this, 'required_files' ), 20 );
+		self::required_files();
 
 	}
 
@@ -179,7 +179,7 @@ class WC_NYP_Tickets {
 	 * @return      void
 	 * @since       0.1.0
 	 */
-	public function required_files(){
+	public function required_files() {
 		// include admin class to handle all backend functions
 		if( is_admin() ){
 			include_once( 'includes/class-wc-nyp-tickets-admin.php' );
@@ -280,4 +280,4 @@ function WC_NYP_Tickets() {
 }
 
 // Launch the whole plugin
-add_action( 'plugins_loaded', 'WC_NYP_Tickets' );
+add_action( 'plugins_loaded', 'WC_NYP_Tickets', 20 );


### PR DESCRIPTION
Closes #1 

Attempt at re-patching compatibility with new Events Tickets Plus. Requires Tickets 5, Name Your Price 3, and Woo 4.7. 

*Fix admin checkbox toggle
*Save _has_nyp meta on event
*Add post_class to event
*style ticket blocks with NYP tickets as full-width
*front-end: use template to display NYP price input
*front-end: update total prices when price is entered
*front-end: prevent add to cart when a selected ticket is NYP and has an invalid price.

One thing will be fixed in the next version of NYP... relating to listening to the "get tickets" (add to cart button click). Until then the submit may not be blocked if you have an invalid price on a ticket.

![image](https://user-images.githubusercontent.com/507025/98979830-12fce980-24d9-11eb-8a22-b9a48d07c0e8.png)
